### PR TITLE
Change order of include paths to make libstdc++ happy

### DIFF
--- a/src/wclang.cpp
+++ b/src/wclang.cpp
@@ -1627,9 +1627,21 @@ int main(int argc, char **argv)
             if ((p = getenv("WCLANG_NO_INTEGRATED_AS")) && *p == '1')
                 args.push_back("-no-integrated-as");
 
+            /*
+             * For libstdc++ 6, the C++ includes must appear before the standard
+             * includes.
+             *
+             * libstdc++ 6 is very picky if you use -isystem for system include
+             * directories. It needs the C++ path first, otherwise it errors out
+             * with "'stdlib.h' file not found".
+             *
+             * This is a known problem and apparently will not be fixed upstream:
+             *
+             * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129
+             */
             pushdirs(intrinpaths);
-            pushdirs(stdpaths);
             pushdirs(cxxpaths);
+            pushdirs(stdpaths);
         }
     }
 


### PR DESCRIPTION
It turns out that libstdc++ 6 is very picky if you override a system
include path with -isystem (not with -I). Unless you put the STL libs
first, it will error out like this:

    In file included from ../../src/main.cpp:5:
    In file included from /usr/x86_64-w64-mingw32/include/c++/6.1.1/iostream:39:
    In file included from /usr/x86_64-w64-mingw32/include/c++/6.1.1/ostream:38:
    In file included from /usr/x86_64-w64-mingw32/include/c++/6.1.1/ios:42:
    In file included from /usr/x86_64-w64-mingw32/include/c++/6.1.1/bits/ios_base.h:41:
    In file included from /usr/x86_64-w64-mingw32/include/c++/6.1.1/bits/locale_classes.h:40:
    In file included from /usr/x86_64-w64-mingw32/include/c++/6.1.1/string:52:
    In file included from /usr/x86_64-w64-mingw32/include/c++/6.1.1/bits/basic_string.h:5402:
    In file included from /usr/x86_64-w64-mingw32/include/c++/6.1.1/ext/string_conversions.h:41:
    In file included from /usr/x86_64-w64-mingw32/include/c++/6.1.1/cstdlib:75:
    /usr/include/c++/6.1.1/stdlib.h:30:16: fatal error: 'stdlib.h' file not found
    # include_next <stdlib.h>
                   ^

This is a known problem by usptream, and apparently will not be fixed

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129