### PR TITLE
README: remove obsolete comment

### DIFF
--- a/README
+++ b/README
@@ -29,7 +29,7 @@ LISTING AVAILABLE PARAMETERS:
  i686-w64-clang -wc-help
 
 LIMITATIONS:
- C++ exceptions do not work with clang prior to 3.7, and in 3.7 (current trunk) just for 64-bit.
+ C++ exceptions do not work with clang prior to 3.7, and in 3.7 just for 64-bit.
 
 KNOWN TO WORK ON:
 


### PR DESCRIPTION
clang's trunk hasn't been 3.7 for a long time.