### PR TITLE
X86 exceptions in Clang>=6.0

### DIFF
--- a/src/wclang.cpp
+++ b/src/wclang.cpp
@@ -1656,6 +1656,11 @@ int main(int argc, char **argv)
                 }
             }
 
+            if (targettype == TARGET_WIN32 && cmdargs.clangversion >= compilerver(6, 0, 0))
+            {
+              args.push_back("-fsjlj-exceptions");
+            }
+
             if ((p = getenv("WCLANG_NO_INTEGRATED_AS")) && *p == '1')
                 args.push_back("-no-integrated-as");
 

--- a/src/wclang.cpp
+++ b/src/wclang.cpp
@@ -1635,7 +1635,7 @@ int main(int argc, char **argv)
                 verbosemsg("detected clang version: %", cmdargs.clangversion.str());
 
             if (cmdargs.exceptions != 0 && (cmdargs.clangversion < compilerver(3, 7, 0) ||
-                targettype == TARGET_WIN32))
+                (targettype == TARGET_WIN32 && cmdargs.clangversion < compilerver(6, 0, 0))))
             {
                 char *p;
                 if (!(p = getenv("WCLANG_FORCE_CXX_EXCEPTIONS")) || *p == '0')


### PR DESCRIPTION
Clang 6.0 finally added support for i686 exceptions!

```
$ i686-w64-mingw32-clang++ --version
clang version 6.0.0 (tags/RELEASE_600/final)
Target: i686-w64-windows-gnu
$ WCLANG_FORCE_CXX_EXCEPTIONS=1 i686-w64-mingw32-clang++ -fsjlj-exceptions main.cxx
$ i686-w64-mingw32-wine a.exe 
caught
ddee
```

Tries to adress x86 exceptions handling (https://github.com/tpoechtrager/wclang/issues/30)

Note the fsjlj flag must be added. There's also an -fseh-exceptions option, maybe that should be used for x86_64 ?